### PR TITLE
Soap client enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: php
 
 ##services:
 
-##env:
+env:
+  global:
+    - marketo_api_id='bigcorp2_458073844B29ACAFC64AC0'
+    - marketo_api_secret='425794457179585644BB2299AACCBB01CC66229C2B35'
+    - marketo_api_uri='https://example.mktoapi.com/soap/mktows/2_9'
 
 php:
   - 5.3

--- a/src/MarketoSoapApiClient.php
+++ b/src/MarketoSoapApiClient.php
@@ -106,13 +106,54 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
         $this->secretKey = $secretKey;
         $this->soapClient = $soapClient;
         $this->namespace = $namespace;
-        if ($dateTimeZone !== null){
-            $this->dateTimeZone = $dateTimeZone;
-        } else {
-            $this->dateTimeZone = new DateTimeZone('America/Los_Angeles');
-        }
-
+        $this->dateTimeZone = !empty($dateTimeZone)
+            ? $dateTimeZone
+            : date_default_timezone_get();
     }
+
+    /**
+     * Determines lead key type for a given key.
+     *
+     * @param string $key
+     *   The key to examine
+     *
+     * @return string
+     *   Lead key type
+     */
+    protected function keyType($key) {
+      if (filter_var($key, FILTER_VALIDATE_EMAIL)) {
+        $type = 'EMAIL';
+      }
+      elseif (is_int($key) || (is_string($key) && ctype_digit($key))) {
+        $type = 'IDNUM';
+      }
+      elseif (filter_var($key, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '/^id:.*&token:.*/')))) {
+        $type = 'COOKIE';
+      }
+      else {
+        $type = 'UNKNOWN';
+      }
+
+      return $type;
+    }
+
+    /**
+     * Sends request to Marketo.
+     *
+     * @param string $operation
+     *   The operation to execute
+     * @param object $params
+     *   Parameters to be sent with the request
+     *
+     * @return object
+     *   Response object
+     */
+    protected function request($operation, $params) {
+      return $this->soapClient->__soapCall(
+        $operation, array($params), array(), $this->createMarketoSoapHeader()
+      );
+    }
+
 
     /**
      * Returns Marketo SOAP API required request signature for including in
@@ -127,14 +168,10 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
         $timeStamp = $dtObj->format(DATE_W3C);
         $encryptString = $timeStamp . $this->userId;
 
-        $signature['hash'] = hash_hmac(
-            'sha1',
-            $encryptString,
-            $this->secretKey
+        return array(
+          'hash' => hash_hmac('sha1', $encryptString, $this->secretKey),
+          'timeStamp' => $timeStamp,
         );
-        $signature['timeStamp'] = $timeStamp;
-
-        return $signature;
 
     }
 
@@ -146,10 +183,7 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
      */
     protected function createMarketoSoapHeader(){
 
-        $signature = $this->createMarketoSoapHeaderSignature(
-            $this->userId,
-            $this->secretKey
-        );
+        $signature = $this->createMarketoSoapHeaderSignature();
         $attrs = new stdClass();
         $attrs->mktowsUserId = $this->userId;
         $attrs->requestSignature = $signature['hash'];
@@ -315,7 +349,69 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
             error_log ("Error Accessing Marketo SOAP API: ".$ex->getMessage());
             throw ($ex);
         }
+    }
 
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLeadActivity($key, $type = NULL) {
+      $lead = new stdClass();
+      $lead->leadKey = new stdClass();
+      $lead->leadKey->keyType = (is_null($type)) ? $this->keyType($key) : strtoupper($type);
+      $lead->leadKey->keyValue = $key;
+      $lead->activityFilter = new stdClass();
+      $lead->startPosition = new stdClass();
+      $lead->batchSize = 100;
+
+      try {
+        $result = $this->request('getLeadActivity', $lead);
+        $activity = $this->prepareLeadActivityResults($result);
+      }
+      catch (\SoapFault $e) {
+
+        if ($this->getErrorCode($e) == MarketoSoapError::ERR_LEAD_NOT_FOUND) {
+          // No leads were found.
+          $activity = array();
+        }
+        else {
+          throw new Exception($e);
+        }
+      }
+
+      return $activity;
+    }
+
+
+    /**
+     * Parses lead activity results into a more useful format.
+     *
+     * @param object $marketo_result
+     *   SOAP response
+     *
+     * @return array
+     *   An array of objects defining lead activity data
+     */
+    protected function prepareLeadActivityResults($marketo_result) {
+      if ($marketo_result->leadActivityList->returnCount > 1) {
+        $activity = $marketo_result->leadActivityList->activityRecordList->activityRecord;
+      }
+      elseif ($marketo_result->leadActivityList->returnCount == 1) {
+        $activity[] = $marketo_result->leadActivityList->activityRecordList->activityRecord;
+      }
+      else {
+        $activity = array();
+      }
+
+      foreach ($activity as &$event) {
+        $event->attributes = array();
+        foreach ($event->activityAttributes->attribute as $attribute) {
+          $event->attributes[$attribute->attrName] = $attribute->attrValue;
+        }
+        unset($event->activityAttributes);
+      }
+
+      return $activity;
     }
 
     /**
@@ -488,6 +584,22 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
 
         return true;
 
+    }
+
+    /**
+     * Gets a SOAP exception error code.
+     *
+     * @see http://php.net/manual/en/class.soapfault.php
+     *
+     * @param \SoapFault $ex
+     *   The SOAP fault object.
+     * @return int
+     *   The error code.
+     */
+    protected function getErrorCode(\SoapFault $ex) {
+      return !empty($ex->detail->serviceException->code)
+        ? $ex->detail->serviceException->code
+        : 1;
     }
 
 }

--- a/src/MarketoSoapApiClient.php
+++ b/src/MarketoSoapApiClient.php
@@ -340,9 +340,7 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
             return $this->formatLeads($leads, $flattenAttributes);
 
         } catch(SoapFault $ex) {
-            if (
-                isset($ex->detail)
-                && $ex->detail->serviceException->code === '20103'
+            if ( $this->getErrorCode($ex) === MarketoSoapError::ERR_LEAD_NOT_FOUND
             ){
                 return false;
             }

--- a/src/MarketoSoapApiClient.php
+++ b/src/MarketoSoapApiClient.php
@@ -523,9 +523,9 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
      * {@inheritdoc}
      */
     public function getFields() {
-        $params = array(
-            'objectName' => 'LeadRecord',
-        );
+        $params = new stdClass();
+        $params->objectName = 'LeadRecord';
+
         try {
             $result = $this->request('describeMObject', $params);
             $fields = $this->prepareFieldResults($result);

--- a/src/MarketoSoapApiClient.php
+++ b/src/MarketoSoapApiClient.php
@@ -108,7 +108,7 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
         $this->namespace = $namespace;
         $this->dateTimeZone = !empty($dateTimeZone)
             ? $dateTimeZone
-            : date_default_timezone_get();
+            : new DateTimeZone(date_default_timezone_get());
     }
 
     /**
@@ -570,7 +570,7 @@ class MarketoSoapApiClient implements MarketoSoapApiClientInterface {
         }
 
         if ($runAt === null){
-            $runAt = new DateTime('now',$this->dateTimeZone);
+            $runAt = new DateTime('now', $this->dateTimeZone);
         }
 
         // Create Request

--- a/src/MarketoSoapApiClientInterface.php
+++ b/src/MarketoSoapApiClientInterface.php
@@ -58,6 +58,11 @@ interface MarketoSoapApiClientInterface {
     );
 
     /**
+     * Retrieves list of defined fields.
+     */
+    public function getFields();
+
+    /**
      * Sets and returns Marketo SOAP API Client options
      *
      * @param string $soapEndpoint Marketo SOAP API end point URL

--- a/src/MarketoSoapApiClientInterface.php
+++ b/src/MarketoSoapApiClientInterface.php
@@ -97,6 +97,16 @@ interface MarketoSoapApiClientInterface {
     public function getLeadBy ($type, $value, $flattenAttributes = true);
 
     /**
+     * Retrieves lead activity information.
+     *
+     * @param string $key
+     *   Lead Key, typically email address.
+     * @param string $type
+     *   Lead key type, auto-detection attempted if not supplied.
+     */
+    public function getLeadActivity($key, $type);
+
+  /**
      * Create or update lead information
      *
      * Examples

--- a/src/MarketoSoapApiClientInterface.php
+++ b/src/MarketoSoapApiClientInterface.php
@@ -59,6 +59,9 @@ interface MarketoSoapApiClientInterface {
 
     /**
      * Retrieves list of defined fields.
+     *
+     * @return array
+     *   An array of lead fields defined in marketo.
      */
     public function getFields();
 

--- a/src/MarketoSoapError.php
+++ b/src/MarketoSoapError.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GaelAbadin\MarketoSoap;
+
+/**
+ * Marketo errors.
+ */
+class MarketoSoapError {
+
+  const ERR_SEVERE_INTERNAL_ERROR = 10001;
+  const ERR_INTERNAL_ERROR = 20011;
+  const ERR_REQUEST_NOT_UNDERSTOOD = 20012;
+  const ERR_ACCESS_DENIED = 20013;
+  const ERR_AUTH_FAILED = 20014;
+  const ERR_REQUEST_LIMIT_EXCEEDED = 20015;
+  const ERR_REQ_EXPIRED = 20016;
+  const ERR_INVALID_REQ = 20017;
+  const ERR_BAD_ENCODING = 20018;
+  const ERR_UNSUPPORTED_OP = 20019;
+
+  const ERR_LEAD_KEY_REQ = 20101;
+  const ERR_LEAD_KEY_BAD = 20102;
+  const ERR_LEAD_NOT_FOUND = 20103;
+  const ERR_LEAD_DETAIL_REQ = 20104;
+  const ERR_LEAD_ATTRIB_BAD = 20105;
+  const ERR_LEAD_SYNC_FAILED = 20106;
+  const ERR_ACTIVITY_KEY_BAD = 20107;
+  const ERR_PARAMETER_REQ = 20109;
+  const ERR_PARAMETER_BAD = 20110;
+  const ERR_LIST_NOT_FOUND = 20111;
+  const ERR_CAMP_NOT_FOUND = 20113;
+  const ERR_BAD_PARAMETER = 20114;
+  const ERR_BAD_STREAM_POS = 20122;
+  const ERR_STREAM_AT_END = 20123;
+
+}

--- a/src/MarketoSoapError.php
+++ b/src/MarketoSoapError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GaelAbadin\MarketoSoap;
+namespace CodeCrafts\MarketoSoap;
 
 /**
  * Marketo errors.

--- a/tests/phpunit/MarketoSoapApiClientTest.php
+++ b/tests/phpunit/MarketoSoapApiClientTest.php
@@ -21,15 +21,25 @@ class MarketoSoapApiClientTest extends PHPUnit_Framework_TestCase {
 
   private function getMarketoSoapApiClient($soapClientMockupResponse){
 
-    $soapClientMockup = new SoapClientMockup('path/to/wsdl');
+    // Get API credentials from environment variables. Can use travis encryption
+    // for storage. See: <https://docs.travis-ci.com/user/encryption-keys/>.
+    $id = getenv('marketo_api_id');
+    $secret = getenv('marketo_api_secret');
+    $uri = getenv('marketo_api_uri');
+
+
+    $this->assertNotEmpty($id, 'The `marketo_api_id` environment variable is empty.');
+    $this->assertNotEmpty($secret, 'The `marketo_api_secret` environment variable is empty.');
+    $this->assertNotEmpty($uri, 'The `marketo_api_uri` environment variable is empty.');
+
+    $soapClientMockup = new SoapClientMockup($uri.'?WSDL');
     $soapClientMockup->expectedResponse = $soapClientMockupResponse;
 
     $marketoSoapApiClient = new MarketoSoapApiClient(
-      'someUserId',
-      'someSecretKey',
+      $id,
+      $secret,
       $soapClientMockup
     );
-
 
     return $marketoSoapApiClient;
 


### PR DESCRIPTION
This adds a couple of calls I need but doesn't add any test coverage for them. 

The global environment variables are so travis could run actual tests. Sensitive data can be handled by travis encryption (https://docs.travis-ci.com/user/encryption-keys/) if anyone has a sandbox that could be used for testing for any length of time.

I realize that the conversion to environment variable for testing is incomplete but it's all the time I had for this feature at the moment.
